### PR TITLE
Now suppress loading messages

### DIFF
--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -268,7 +268,15 @@ This function uses `geiser-chicken-init-file' if it exists."
   (let ((geiser-log-verbose-p t)
         (geiser-chicken-load-file (expand-file-name "chicken/geiser/emacs.scm" geiser-scheme-dir)))
     (if geiser-chicken-compile-geiser-p
-      (geiser-eval--send/wait (format "(use utils)(compile-file \"%s\")(import geiser)"
+      (geiser-eval--send/wait (format "
+;; Sadly, (use import compile-file) must be run at top-level, so we have a stdout binding
+(define geiser-stdout (current-output-port))
+(current-output-port (make-output-port (lambda a #f) (lambda a #f)))
+(use utils)
+(compile-file \"%s\")
+(import geiser)
+(current-output-port geiser-stdout)
+"
                                       geiser-chicken-load-file))
       (geiser-eval--send/wait (format "(load \"%s\")"
                                       geiser-chicken-load-file)))))


### PR DESCRIPTION
Chicken won't become available to Geiser until it's actually done
loading. A number of bugs are related to this, including jaor/geiser#68
but also some quizzically flaky completion behaviour.

The fix is to suppress output to STDOUT until Chicken is ready; output
to STDERR is not suppressed, so if bad things happen it will still
appear in the geiser messages buffer.

This may fix jaor/geiser#68