### PR TITLE
Adds necessary parameter to csi for Windows.

### DIFF
--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -47,9 +47,9 @@
   :group 'geiser)
 
 (geiser-custom--defcustom geiser-chicken-binary
-  (cond ((eq system-type 'windows-nt) "csi.exe")
-        ((eq system-type 'darwin) "csi")
-        (t "csi"))
+  (cond ((eq system-type 'windows-nt) '("csi.exe" "-:c"))
+	((eq system-type 'darwin) "csi")
+	(t "csi"))
   "Name to use to call the Chicken executable when starting a REPL."
   :type '(choice string (repeat string))
   :group 'geiser-chicken)


### PR DESCRIPTION
-:c is required to make csi behave nicely with Emacs on Windows.

This ought to resolve jaor/geiser#67