### PR TITLE
Use pretty-print instead of write with Chicken

### DIFF
--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -259,11 +259,11 @@
       (set! result
         (cond
          ((list? result)
-          (map (lambda (v) (with-output-to-string (lambda () (write v)))) result))
+          (map (lambda (v) (with-output-to-string (lambda () (pretty-print v)))) result))
          ((eq? result (if #f #t))
           (list output))
          (else
-          (list (with-output-to-string (lambda () (write result)))))))
+          (list (with-output-to-string (lambda () (pretty-print result)))))))
 
       (let ((out-form
              `((result ,@result)


### PR DESCRIPTION
Emacs chokes on buffers with very long lines. Use of pretty-print
instead of write causes most incidents of long lines to be avoided by
use of better formatting.

This fixes jaor/geiser#64 for Chicken, and appears to greatly speed up
completions in the general case for Chicken.