### PR TITLE
Fixes an issue where symbol->string was failing

### DIFF
--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -229,7 +229,7 @@
     (string-append "^([^#]+#)*" (regexp-escape prefix)))
 
   (define (describe-symbol sym #!key (exact? #f))
-    (let* ((str (symbol->string sym))
+    (let* ((str (->string sym))
            (found (apropos-information-list (regexp (make-apropos-regex str)) #:macros? #t)))
       (delete-duplicates
        (if exact?
@@ -339,7 +339,7 @@
 
   ;; Builds a signature list from an identifier
   (define (find-signatures toplevel-module sym)
-    (define str (symbol->string sym))
+    (define str (->string sym))
 
     (define (make-module-list sym module-sym)
       (if (null? module-sym)

--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -375,7 +375,7 @@
                 (args (if (or (list? rest) (pair? rest)) (cdr rest) '())))
 
             (define (clean-arg arg)
-              (string->symbol (string-substitute "(.*[^0-9]+)[0-9]+" "\\1" (symbol->string arg))))
+              (string->symbol (string-substitute "(.*[^0-9]+)[0-9]+" "\\1" (->string arg))))
 
             (define (collect-args args #!key (reqs? #t) (opts? #f) (keys? #f))
               (when (not (null? args))


### PR DESCRIPTION
In some instances apropos-information-list returns a string and not a
list of symbols; this is the case for Chicken's builtins, like C_plus.

IE, the following would fail:
(geiser-autodoc #f '(+))

This fixes jaor/geiser#72