### PR TITLE
Add compiled .so caching to Chicken support

### DIFF
--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -47,9 +47,9 @@
   :group 'geiser)
 
 (geiser-custom--defcustom geiser-chicken-binary
-  (cond ((eq system-type 'windows-nt) "csi.exe")
-        ((eq system-type 'darwin) "csi")
-        (t "csi"))
+  (cond ((eq system-type 'windows-nt) '("csi.exe" "-:c"))
+	((eq system-type 'darwin) "csi")
+	(t "csi"))
   "Name to use to call the Chicken executable when starting a REPL."
   :type '(choice string (repeat string))
   :group 'geiser-chicken)

--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -48,8 +48,8 @@
 
 (geiser-custom--defcustom geiser-chicken-binary
   (cond ((eq system-type 'windows-nt) '("csi.exe" "-:c"))
-	((eq system-type 'darwin) "csi")
-	(t "csi"))
+        ((eq system-type 'darwin) "csi")
+        (t "csi"))
   "Name to use to call the Chicken executable when starting a REPL."
   :type '(choice string (repeat string))
   :group 'geiser-chicken)

--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -47,9 +47,9 @@
   :group 'geiser)
 
 (geiser-custom--defcustom geiser-chicken-binary
-  (cond ((eq system-type 'windows-nt) '("csi.exe" "-:c"))
-        ((eq system-type 'darwin) "csi")
-        (t "csi"))
+    (cond ((eq system-type 'windows-nt) '("csi.exe" "-:c"))
+	  ((eq system-type 'darwin) "csi")
+          (t "csi"))
   "Name to use to call the Chicken executable when starting a REPL."
   :type '(choice string (repeat string))
   :group 'geiser-chicken)
@@ -104,11 +104,11 @@ This function uses `geiser-chicken-init-file' if it exists."
   (let ((init-file (and (stringp geiser-chicken-init-file)
                         (expand-file-name geiser-chicken-init-file)))
         (n-flags (and (not geiser-chicken-load-init-file-p) '("-n"))))
-  `(,@(and (listp geiser-chicken-binary) (cdr geiser-chicken-binary))
-    ,@n-flags "-include-path" ,(expand-file-name "chicken/" geiser-scheme-dir)
-    ,@(apply 'append (mapcar (lambda (p) (list "-include-path" p))
-                             geiser-chicken-load-path))
-    ,@(and init-file (file-readable-p init-file) (list init-file)))))
+    `(,@(and (listp geiser-chicken-binary) (cdr geiser-chicken-binary))
+      ,@n-flags "-include-path" ,(expand-file-name "chicken/" geiser-scheme-dir)
+      ,@(apply 'append (mapcar (lambda (p) (list "-include-path" p))
+			       geiser-chicken-load-path))
+      ,@(and init-file (file-readable-p init-file) (list init-file)))))
 
 (defconst geiser-chicken--prompt-regexp "#[^;]*;[^:0-9]*:?[0-9]+> ")
 

--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -263,23 +263,31 @@ This function uses `geiser-chicken-init-file' if it exists."
   (interactive)
   (geiser-connect 'chicken))
 
+(defun geiser-chicken--compile-or-load (force-load)
+  (let ((target 
+	 (expand-file-name "chicken/geiser/emacs.so" geiser-scheme-dir))
+	(source
+	 (expand-file-name "chicken/geiser/emacs.scm" geiser-scheme-dir))
+	(force-load (or force-load (eq system-type 'windows-nt)))
+	(suppression-prefix
+	 "(define geiser-stdout (current-output-port))(current-output-port (make-output-port (lambda a #f) (lambda a #f)))")
+	(suppression-postfix
+	 "(current-output-port geiser-stdout)"))
+    (let ((load-sequence
+	   (cond
+	    (force-load
+	     (format "(load \"%s\")\n" source))
+	    ((file-exists-p target)
+	     (format "%s(load \"%s\")(import geiser)%s\n"
+		     suppression-prefix target suppression-postfix))
+	    (t
+	     (format "%s(use utils)(compile-file \"%s\" options: '(\"-O3\") output-file: \"%s\"load: #t)(import geiser)%s\n"
+		     suppression-prefix source target suppression-postfix)))))
+      (geiser-eval--send/wait load-sequence))))
+
 (defun geiser-chicken--startup (remote)
   (compilation-setup t)
-  (let ((geiser-log-verbose-p t)
-        (geiser-chicken-load-file (expand-file-name "chicken/geiser/emacs.scm" geiser-scheme-dir)))
-    (if geiser-chicken-compile-geiser-p
-      (geiser-eval--send/wait (format "
-;; Sadly, (use import compile-file) must be run at top-level, so we have a stdout binding
-(define geiser-stdout (current-output-port))
-(current-output-port (make-output-port (lambda a #f) (lambda a #f)))
-(use utils)
-(compile-file \"%s\")
-(import geiser)
-(current-output-port geiser-stdout)
-"
-                                      geiser-chicken-load-file))
-      (geiser-eval--send/wait (format "(load \"%s\")"
-                                      geiser-chicken-load-file)))))
+  (geiser-chicken--compile-or-load (not geiser-chicken-compile-geiser-p)))
 
 ;;; Implementation definition:
 

--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -229,7 +229,7 @@
     (string-append "^([^#]+#)*" (regexp-escape prefix)))
 
   (define (describe-symbol sym #!key (exact? #f))
-    (let* ((str (symbol->string sym))
+    (let* ((str (->string sym))
            (found (apropos-information-list (regexp (make-apropos-regex str)) #:macros? #t)))
       (delete-duplicates
        (if exact?
@@ -339,7 +339,7 @@
 
   ;; Builds a signature list from an identifier
   (define (find-signatures toplevel-module sym)
-    (define str (symbol->string sym))
+    (define str (->string sym))
 
     (define (make-module-list sym module-sym)
       (if (null? module-sym)

--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -259,11 +259,11 @@
       (set! result
         (cond
          ((list? result)
-          (map (lambda (v) (with-output-to-string (lambda () (write v)))) result))
+          (map (lambda (v) (with-output-to-string (lambda () (pretty-print v)))) result))
          ((eq? result (if #f #t))
           (list output))
          (else
-          (list (with-output-to-string (lambda () (write result)))))))
+          (list (with-output-to-string (lambda () (pretty-print result)))))))
 
       (let ((out-form
              `((result ,@result)

--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -375,7 +375,7 @@
                 (args (if (or (list? rest) (pair? rest)) (cdr rest) '())))
 
             (define (clean-arg arg)
-              (string->symbol (string-substitute "(.*[^0-9]+)[0-9]+" "\\1" (symbol->string arg))))
+              (string->symbol (string-substitute "(.*[^0-9]+)[0-9]+" "\\1" (->string arg))))
 
             (define (collect-args args #!key (reqs? #t) (opts? #f) (keys? #f))
               (when (not (null? args))


### PR DESCRIPTION
- Now give compile-file a reasonable destination for the output
- Check for aforementioned output and skip the compile if exists
- None of the above happens if the system-type is 'windows-nt,
  which may not be a necessary restriction. And, the existing
  geiser-chicken-compile-geiser-p var applies.

Resolves jaor/geiser#73 for non-windows system