### PR TITLE
Load implementations when they are needed

### DIFF
--- a/elisp/geiser-impl.el
+++ b/elisp/geiser-impl.el
@@ -340,8 +340,3 @@ buffer contains Scheme code of the given implementation.")
 
 
 (provide 'geiser-impl)
-
-
-;;; Initialization:
-;; After providing 'geiser-impl, so that impls can use us.
-(mapc 'geiser-impl--load-impl geiser-active-implementations)

--- a/elisp/geiser-repl.el
+++ b/elisp/geiser-repl.el
@@ -352,6 +352,7 @@ module command as a string")
         (error "Geiser requires %s version %s but detected %s" impl r v)))))
 
 (defun geiser-repl--start-repl (impl address)
+  (geiser-impl--load-impl impl)
   (message "Starting Geiser REPL for %s ..." impl)
   (when (not address) (geiser-repl--check-version impl))
   (geiser-repl--to-repl-buffer impl)


### PR DESCRIPTION
Hello, I would like to avoid loading all (active) implementations
after loading `geiser-impl` and to make them being loaded only when
they are needed.  This should also fix #82.

IIUC an implementation should be loaded in the following cases:

- After enabling `geiser-mode`.  This case doesn't require any
  additional tweaking as `geiser-mode` calls
  `geiser-impl--set-buffer-implementation`, which loads the required
  implementation.

- When `run-geiser`/`switch-to-geiser`/`geiser-connect` or a particular
  wrapper (`run-guile`, `switch-to-racket`, ...) is called.  As all
  these commands run `geiser-repl--start-repl`, I think all
  is need to be done in this case is to load an implementation inside
  this function.

The commit message is not very verbose, so let me know if I should
improve it.