### PR TITLE
Remove Geiser faces from 'faces' custom group

### DIFF
--- a/elisp/geiser-custom.el
+++ b/elisp/geiser-custom.el
@@ -35,8 +35,7 @@
     `(defface ,face (face-default-spec ,def)
        ,(format "Face for %s." doc)
        :group ',group
-       :group 'geiser-faces
-       :group 'faces)))
+       :group 'geiser-faces)))
 
 (put 'geiser-custom--defface 'lisp-indent-function 1)
 


### PR DESCRIPTION
If you call `M-x customize-group RET faces` you'll see geiser faces
there.  If I undertstand correctly this is very unusual (I don't see any
other package does this).  I think it is enough to have `Geiser Faces`
subgroup there.
