### PR TITLE
Skip expression quote when getting a racket symbol

### DIFF
--- a/elisp/geiser-racket.el
+++ b/elisp/geiser-racket.el
@@ -178,7 +178,7 @@ using start-geiser, a procedure in the geiser/server module."
         (t nil)))
 
 (defun geiser-racket--symbol-begin (module)
-  (save-excursion (skip-syntax-backward "^-()>") (point)))
+  (save-excursion (skip-syntax-backward "^'-()>") (point)))
 
 (defun geiser-racket--import-command (module)
   (and (stringp module)


### PR DESCRIPTION
This changes allows to capture a symbol without quotation charaters in racket for completion