### PR TITLE
Add more indentation rules and highlighting.

### DIFF
--- a/elisp/geiser-guile.el
+++ b/elisp/geiser-guile.el
@@ -247,14 +247,19 @@ This function uses `geiser-guile-init-file' if it exists."
 
 (defconst geiser-guile--builtin-keywords
   '("call-with-input-file"
-    "call-with-output-file"
     "call-with-input-string"
+    "call-with-output-file"
     "call-with-output-string"
+    "call-with-prompt"
+    "call-with-trace"
     "define-accessor"
     "define-class"
     "define-enumeration"
     "define-inlinable"
+    "define-syntax-parameter"
+    "eval-when"
     "lambda*"
+    "syntax-parameterize"
     "use-modules"
     "with-error-to-file"
     "with-error-to-port"
@@ -283,9 +288,13 @@ This function uses `geiser-guile-init-file' if it exists."
  (c-lambda 2)
  (call-with-input-string 1)
  (call-with-output-string 0)
+ (call-with-prompt 1)
+ (call-with-trace 0)
+ (eval-when 1)
  (lambda* 1)
  (pmatch defun)
  (sigaction 1)
+ (syntax-parameterize 1)
  (with-error-to-file 1)
  (with-error-to-port 1)
  (with-error-to-string 0)
@@ -295,8 +304,8 @@ This function uses `geiser-guile-init-file' if it exists."
  (with-input-from-string 1)
  (with-method 1)
  (with-mutex 1)
- (with-output-to-string 0))
-
+ (with-output-to-string 0)
+ (with-throw-handler 1))
 
 
 ;;; Compilation shell regexps

--- a/elisp/geiser-syntax.el
+++ b/elisp/geiser-syntax.el
@@ -33,6 +33,7 @@
  (catch defun)
  (class defun)
  (dynamic-wind 0)
+ (guard 1)
  (let*-values 1)
  (let-values 1)
  (let/ec 1)
@@ -52,6 +53,7 @@
  (unless 1)
  (when 1)
  (while 1)
+ (with-exception-handler 1)
  (with-syntax 1))
 
 
@@ -78,6 +80,7 @@
     "set!"
     "unless"
     "when"
+    "with-exception-handler"
     "with-input-from-file"
     "with-output-to-file"))
 

--- a/elisp/geiser-syntax.el
+++ b/elisp/geiser-syntax.el
@@ -50,6 +50,20 @@
  (receive 2)
  (require-extension 0)
  (syntax-case 2)
+ (test-approximate 1)
+ (test-assert 1)
+ (test-eq 1)
+ (test-equal 1)
+ (test-eqv 1)
+ (test-group-with-cleanup 1)
+ (test-runner-on-bad-count! 1)
+ (test-runner-on-bad-end-name! 1)
+ (test-runner-on-final! 1)
+ (test-runner-on-group-begin! 1)
+ (test-runner-on-group-end! 1)
+ (test-runner-on-test-begin! 1)
+ (test-runner-on-test-end! 1)
+ (test-with-runner 1)
  (unless 1)
  (when 1)
  (while 1)
@@ -78,6 +92,17 @@
     "receive"
     "require-extension"
     "set!"
+    "test-approximate"
+    "test-assert"
+    "test-begin"
+    "test-end"
+    "test-eq"
+    "test-equal"
+    "test-eqv"
+    "test-error"
+    "test-group"
+    "test-group-with-cleanup"
+    "test-with-runner"
     "unless"
     "when"
     "with-exception-handler"

--- a/elisp/geiser-syntax.el
+++ b/elisp/geiser-syntax.el
@@ -92,6 +92,7 @@
     "receive"
     "require-extension"
     "set!"
+    "syntax-case"
     "test-approximate"
     "test-assert"
     "test-begin"


### PR DESCRIPTION
I made several commits for clearness, or should I squash them into a
single one?

SRFI-64 (tests) is rather big, so I could miss some things that should
be indented specially.  Also I added highlighting for procedures that
can be used in the top-level (`test-begin`, `test-eq`, ...), but maybe
it's too much, and only `test-group-with-cleanup` and `test-with-runner`
should be highlighted, WDYT?
