### PR TITLE
Chicken faster completions

### DIFF
--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -296,7 +296,7 @@ This function uses `geiser-chicken-init-file' if it exists."
              (format "%s(load \"%s\")(import geiser)%s\n"
                      suppression-prefix target suppression-postfix))
             (t
-             (format "%s(use utils)(compile-file \"%s\" options: '(\"-O3\") output-file: \"%s\" load: #t)(import geiser)%s\n"
+             (format "%s(use utils)(compile-file \"%s\" options: '(\"-O3\" \"-s\") output-file: \"%s\" load: #t)(import geiser)%s\n"
                      suppression-prefix source target suppression-postfix)))))
       (geiser-eval--send/wait load-sequence))))
 

--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -476,11 +476,11 @@
 
     (define (form-has-safe-geiser? form)
       (any (cut eq? (car form) <>)
-	   '(geiser-no-values geiser-newline geiser-start-server geiser-completions
+	   '(geiser-no-values geiser-newline geiser-completions
 	     geiser-autodoc geiser-object-signature geiser-symbol-location
 	     geiser-symbol-documentation geiser-find-file geiser-add-to-load-path
 	     geiser-module-exports geiser-module-path geiser-module-location
-	     geiser-module-completions geiser-macroexpand geiser-use-debug-log)))
+	     geiser-module-completions geiser-use-debug-log)))
     
     (when (and module
 	       (not (symbol? module)))

--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -31,7 +31,6 @@
   (use
     apropos
     chicken-doc
-    csi
     data-structures
     extras
     ports

--- a/scheme/chicken/geiser/emacs.scm
+++ b/scheme/chicken/geiser/emacs.scm
@@ -211,7 +211,7 @@
   ;; Utilities
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-  (define geiser-use-debug-log (make-parameter #t))
+  (define geiser-use-debug-log (make-parameter #f))
 
   (define find-module ##sys#find-module)
   (define current-module ##sys#current-module)


### PR DESCRIPTION
This is a partial fix for #100 

Basically, the cause of the problems was too much regex. Sadly, the entirety of the issue cannot be undone due to the use of regex within the apropos egg. There remains some possibility of minor gains in the chicken geiser implementation, but nothing within two order of magnitude of the apropos slow down.

However, as a result of the changes in this PR I witnessed geiser-autdoc and geiser-completions drop from 1.3 seconds to 0.25 seconds, in the nightmare environment. Thanks to the addition of memoization, subsequent calls with the same parameters take 0.001 seconds. Memoization is cleared whenever requests are processed that may change the environment.