### PR TITLE
Use OS-specific quotes in shell-command-to-string invocations

### DIFF
--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -270,8 +270,7 @@ This function uses `geiser-chicken-init-file' if it exists."
 (defconst geiser-chicken-minimum-version "4.8.0.0")
 
 (defun geiser-chicken--version (binary)
-  (shell-command-to-string (format "%s -e \"(display (chicken-version))\""
-                                   binary)))
+  (shell-command-to-string (format "%s -e %s" binary (shell-quote-argument "(display (chicken-version))"))))
 
 (defun connect-to-chicken ()
   "Start a Chicken REPL connected to a remote process."

--- a/elisp/geiser-guile.el
+++ b/elisp/geiser-guile.el
@@ -335,7 +335,7 @@ This function uses `geiser-guile-init-file' if it exists."
 (defconst geiser-guile-minimum-version "2.0")
 
 (defun geiser-guile--version (binary)
-  (shell-command-to-string (format "%s  -c '(display (version))'" binary)))
+  (shell-command-to-string (format "%s -c %s" binary (shell-quote-argument "(display (version))"))))
 
 (defun geiser-guile-update-warning-level ()
   "Update the warning level used by the REPL.

--- a/elisp/geiser-racket.el
+++ b/elisp/geiser-racket.el
@@ -363,7 +363,7 @@ using start-geiser, a procedure in the geiser/server module."
 (defvar geiser-racket-minimum-version "5.3")
 
 (defun geiser-racket--version (binary)
-  (shell-command-to-string (format "%s  -e '(display (version))'" binary)))
+  (shell-command-to-string (format "%s -e %s" binary (shell-quote-argument "(display (version))"))))
 
 (defvar geiser-racket--image-cache-dir nil)
 


### PR DESCRIPTION
Per https://github.com/jaor/geiser/issues/95

This commit makes shell-command-to-string invocations use OS-specific quotes in geiser-*--version functions, 