### PR TITLE
Fuzzy matching for Chicken AutoDoc and Completions

### DIFF
--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -65,12 +65,6 @@
   "Customization for Geiser's Chicken flavour."
   :group 'geiser)
 
-(geiser-custom--defcustom geiser-chicken-prefix-delimiters
-    '("^:" "^#")
-    "Regex to match symbol prefix delimiters. Consider that it will be placed inside []."
-  :type '(repeat string)
-  :group 'geiser-chicken)
-
 (geiser-custom--defcustom geiser-chicken-binary
   (cond ((eq system-type 'windows-nt) '("csi.exe" "-:c"))
         ((eq system-type 'darwin) "csi")
@@ -189,19 +183,10 @@ This function uses `geiser-chicken-init-file' if it exists."
 (defun geiser-chicken--exit-command () ",q")
 
 (defun geiser-chicken--symbol-begin (module)
-  (apply
-   'max
-   (cons
-    (if module
-	(max (save-excursion (beginning-of-line) (point))
-	     (save-excursion (skip-syntax-backward "^(>") (1- (point))))
-      (save-excursion (skip-syntax-backward "^'-()>") (point)))
-    (let ((distance-to-beginning-of-line (- (point) (line-beginning-position))))
-      (mapcar
-       (lambda (match-string)
-	 (save-excursion
-	   (skip-chars-backward match-string distance-to-beginning-of-line) (point)))
-       geiser-chicken-prefix-delimiters)))))
+  (if module
+      (max (save-excursion (beginning-of-line) (point))
+	   (save-excursion (skip-syntax-backward "^(>") (1- (point))))
+    (save-excursion (skip-syntax-backward "^'-()>") (point))))
 
 
 ;;; Error display


### PR DESCRIPTION
Because Chicken allows symbols to be imported with prefixes, and because
'apropos' does not provide any utility to match with the loaded
prefixes, it is difficult to acquire information about prefixed symbols.

This solution hacks around the issue by providing naive
fuzzy-matching. If no match for a symbol can be found then the first
character is dropped and matching is attempted again; the process is
repeated until matches are found or the entire symbol is consumed.

Also removes the (now redundant and slow) geiser-chicken-prefix-delimiters.