### PR TITLE
Highlighting and indentation

### DIFF
--- a/elisp/geiser-syntax.el
+++ b/elisp/geiser-syntax.el
@@ -41,7 +41,7 @@
  (match 1)
  (match-lambda 0)
  (match-lambda* 0)
- (match-let 1)
+ (match-let scheme-let-indent)
  (match-let* 1)
  (match-letrec 1)
  (opt-lambda 1)


### PR DESCRIPTION
Hello, this is another set of indentation & highlighting fixes.  But
please don't merge it now, I'd like to have a discussion on the
font-lock highlighting policy (see below).

1. `match-let` can have a "named" form as `let`, i.e. it can look like this:

   ```scheme
   (match-let loop (...)
     body)
   ```

   While currently it is indented like this:

   ```scheme
   (match-let loop (...)
              body)
   ```

   Sorry, it is my bad (introduced in commit 424553e).

2. The main thing: since `map` is highlighted (by `scheme-mode`), I
   think it would also be good to highlight `filter-map` and
   `append-map`.  But also there are `map!` and `append-map!`.
   Highlight these keywords as well?

   Also there are `fold` and `fold-right`.  And what about `unfold`,
   `unfold-right`, `reduce`, `reduce-right`, `filter`, `partition`,
   `remove` and other things?  I don't have an opinion on these.  On one
   hand `fold` has the same rights as `map`, but OTOH wouldn't it be too
   much if all such procedures were highlighted?

   Also currently `set!` is also font-locked (this highlighting was moved from
   chicken: commit 66f90b1).  I don't like it.

   To sum up: I vote to add highlighting for: `map!`, `append-map`,
   `append-map!` and `filter-map`.  And to remove highlighting for `set!`.
   What do you think?
