### PR TITLE
Performance improvements

### DIFF
--- a/elisp/geiser-connection.el
+++ b/elisp/geiser-connection.el
@@ -228,16 +228,17 @@
     (geiser-con--connection-completed con req)))
 
 (defun geiser-con--connection-add-request (c r)
-  (geiser-log--info "REQUEST: <%s>: %s"
-                    (geiser-con--request-id r)
-                    (geiser-con--request-string r))
-  (geiser-con--connection-activate c)
-  (tq-enqueue (geiser-con--connection-tq c)
-              (concat (geiser-con--request-string r) "\n")
-              (geiser-con--connection-eot c)
-              r
-              'geiser-con--process-completed-request
-              t))
+  (let ((rstr (geiser-con--request-string r)))
+    (geiser-log--info "REQUEST: <%s>: %s"
+                      (geiser-con--request-id r)
+                      rstr)
+    (geiser-con--connection-activate c)
+    (tq-enqueue (geiser-con--connection-tq c)
+                (concat rstr "\n")
+                (geiser-con--connection-eot c)
+                r
+                'geiser-con--process-completed-request
+                t)))
 
 
 ;;; Message sending interface:

--- a/elisp/geiser-connection.el
+++ b/elisp/geiser-connection.el
@@ -43,25 +43,25 @@
         (cons :connection con)))
 
 (defsubst geiser-con--request-id (req)
-  (cdr (assoc :id req)))
+  (cdr (assq :id req)))
 
 (defsubst geiser-con--request-string (req)
-  (cdr (assoc :string req)))
+  (cdr (assq :string req)))
 
 (defsubst geiser-con--request-continuation (req)
-  (cdr (assoc :continuation req)))
+  (cdr (assq :continuation req)))
 
 (defsubst geiser-con--request-buffer (req)
-  (cdr (assoc :buffer req)))
+  (cdr (assq :buffer req)))
 
 (defsubst geiser-con--request-connection (req)
-  (cdr (assoc :connection req)))
+  (cdr (assq :connection req)))
 
 (defsubst geiser-con--request-deactivate (req)
-  (setcdr (assoc :continuation req) nil))
+  (setcdr (assq :continuation req) nil))
 
 (defsubst geiser-con--request-deactivated-p (req)
-  (null (cdr (assoc :continuation req))))
+  (null (cdr (assq :continuation req))))
 
 
 ;;; Connection datatype:
@@ -109,31 +109,31 @@
         (cons :completed (make-hash-table :weakness 'value))))
 
 (defsubst geiser-con--connection-process (c)
-  (tq-process (cdr (assoc :tq c))))
+  (tq-process (cdr (assq :tq c))))
 
 (defsubst geiser-con--connection-filter (c)
-  (cdr (assoc :filter c)))
+  (cdr (assq :filter c)))
 
 (defsubst geiser-con--connection-tq-filter (c)
-  (cdr (assoc :tq-filter c)))
+  (cdr (assq :tq-filter c)))
 
 (defsubst geiser-con--connection-tq (c)
-  (cdr (assoc :tq c)))
+  (cdr (assq :tq c)))
 
 (defsubst geiser-con--connection-eot (c)
-  (cdr (assoc :eot c)))
+  (cdr (assq :eot c)))
 
 (defsubst geiser-con--connection-prompt (c)
-  (cdr (assoc :prompt c)))
+  (cdr (assq :prompt c)))
 
 (defsubst geiser-con--connection-debug-prompt (c)
-  (cdr (assoc :debug-prompt c)))
+  (cdr (assq :debug-prompt c)))
 
 (defsubst geiser-con--connection-is-debugging (c)
-  (cdr (assoc :is-debugging c)))
+  (cdr (assq :is-debugging c)))
 
 (defsubst geiser-con--connection-set-debugging (c d)
-  (setcdr (assoc :is-debugging c) d))
+  (setcdr (assq :is-debugging c) d))
 
 (defun geiser-con--connection-update-debugging (c txt)
   (let* ((dp (geiser-con--connection-debug-prompt c))

--- a/elisp/geiser-eval.el
+++ b/elisp/geiser-eval.el
@@ -175,13 +175,23 @@ module-exports, autodoc, callers, callees and generic-methods.")
         (concat prefix (mapconcat 'identity values nlprefix))
       (or prefix "(No value)"))))
 
-(defsubst geiser-eval--retort-output (ret) (cdr (assoc 'output ret)))
-(defsubst geiser-eval--retort-error (ret) (cdr (assoc 'error ret)))
+(defsubst geiser-eval--retort-output (ret)
+  (cdr (assq 'output ret)))
 
-(defsubst geiser-eval--error-key (err) (cdr (assoc 'key err)))
-(defsubst geiser-eval--error-subr (err) (cdr (assoc 'subr err)))
-(defsubst geiser-eval--error-msg (err) (cdr (assoc 'msg err)))
-(defsubst geiser-eval--error-rest (err) (cdr (assoc 'rest err)))
+(defsubst geiser-eval--retort-error (ret)
+  (cdr (assq 'error ret)))
+
+(defsubst geiser-eval--error-key (err)
+  (cdr (assq 'key err)))
+
+(defsubst geiser-eval--error-subr (err)
+  (cdr (assq 'subr err)))
+
+(defsubst geiser-eval--error-msg (err)
+  (cdr (assq 'msg err)))
+
+(defsubst geiser-eval--error-rest (err)
+  (cdr (assq 'rest err)))
 
 (defun geiser-eval--error-str (err)
   (let* ((key (geiser-eval--error-key err))


### PR DESCRIPTION
Hello, `assq` is the preferable way to pick associations using
symbols.  It should make Geiser a bit faster.  So what about
using assq instead of assoc?

Also I noticed that `geiser-con--request-string` is called twice
in `geiser-con--connection-add-request`, so I fixed it in another
commit.  Is it OK?
