### PR TITLE
Do not use 'geiser-xref--with-buffer' before it is defined

### DIFF
--- a/elisp/geiser-xref.el
+++ b/elisp/geiser-xref.el
@@ -38,6 +38,29 @@
   'bold geiser-xref "headers in cross-reference buffers")
 
 
+;;; Buffer and mode:
+
+(geiser-popup--define xref "*Geiser xref*" geiser-xref-mode)
+
+(defvar geiser-xref-mode-map
+  (let ((map (make-sparse-keymap)))
+    (suppress-keymap map)
+    (set-keymap-parent map button-buffer-map)
+    map))
+
+(defun geiser-xref-mode ()
+  "Major mode for displaying cross-references.
+\\{geiser-xref-mode-map}"
+  (interactive)
+  (kill-all-local-variables)
+  (buffer-disable-undo)
+  (use-local-map geiser-xref-mode-map)
+  (set-syntax-table scheme-mode-syntax-table)
+  (setq mode-name "Geiser Xref")
+  (setq major-mode 'geiser-xref-mode)
+  (setq buffer-read-only t))
+
+
 ;;; Ref button:
 
 (define-button-type 'geiser-xref--button
@@ -120,29 +143,6 @@
                                           (capitalize rkind)
                                           name)
                                   res))))
-
-
-;;; Buffer and mode:
-
-(geiser-popup--define xref "*Geiser xref*" geiser-xref-mode)
-
-(defvar geiser-xref-mode-map
-  (let ((map (make-sparse-keymap)))
-    (suppress-keymap map)
-    (set-keymap-parent map button-buffer-map)
-    map))
-
-(defun geiser-xref-mode ()
-  "Major mode for displaying cross-references.
-\\{geiser-xref-mode-map}"
-  (interactive)
-  (kill-all-local-variables)
-  (buffer-disable-undo)
-  (use-local-map geiser-xref-mode-map)
-  (set-syntax-table scheme-mode-syntax-table)
-  (setq mode-name "Geiser Xref")
-  (setq major-mode 'geiser-xref-mode)
-  (setq buffer-read-only t))
 
 
 ;;; Commands:


### PR DESCRIPTION
Returning to `geiser-XXX--with-buffer` bug.  I wrote that it may also
happen with other files:
https://github.com/jaor/geiser/issues/121#issuecomment-167253958.  And I
finally looked if the other files are influenced.  It appeared that
`geiser-xref.el` has the same problem.  Here is the recipe to reproduce
it (note: elisp files should be compiled!):

1. ``emacs -Q -l "<build-dir>/elisp/geiser-load"``

2. Start the REPL: ``M-x run-guile``

3. Make a scheme buffer:

   - `C-x b tmp`
   - `M-x scheme-mode` (implementation 'guile')

4. Paste the following contents there:

   ```scheme
   (define foo 0)
   (define (bar) foo)
   ```

5. Evaluate it: `C-c C-b`

6. Move point to `foo` symbol and press `C-c <`

And instead of opening an xref buffer, the current buffer is modified
and you get the following error message:

    Invalid function: geiser-xref--with-buffer

The other files (`geiser-log.el` and `geiser-debug.el`) should be OK as
`geiser-popup--define` is called before `geiser-XXX--with-buffer` is
used there.

