### PR TITLE
Use define-derived-mode for major modes

### DIFF
--- a/elisp/geiser-debug.el
+++ b/elisp/geiser-debug.el
@@ -75,18 +75,14 @@ See also `geiser-repl-auto-display-images-p'."
   (let ((map (make-sparse-keymap)))
     (suppress-keymap map)
     (set-keymap-parent map button-buffer-map)
-    map))
+    map)
+  "Keymap for `geiser-debug-mode'.")
 
-(defun geiser-debug-mode ()
+(define-derived-mode geiser-debug-mode nil "Geiser DBG"
   "A major mode for displaying Scheme compilation and evaluation results.
 \\{geiser-debug-mode-map}"
-  (interactive)
-  (kill-all-local-variables)
   (buffer-disable-undo)
-  (use-local-map geiser-debug-mode-map)
   (set-syntax-table scheme-mode-syntax-table)
-  (setq mode-name "Geiser DBG")
-  (setq major-mode 'geiser-debug-mode)
   (setq next-error-function 'geiser-edit--open-next)
   (setq buffer-read-only t))
 

--- a/elisp/geiser-doc.el
+++ b/elisp/geiser-doc.el
@@ -279,12 +279,12 @@ help (e.g. browse an HTML page) implementing this method.")
     (with--geiser-implementation impl
       (geiser-edit-symbol-at-point))))
 
-(defvar geiser-doc-mode-map nil)
-(setq geiser-doc-mode-map
-      (let ((map (make-sparse-keymap)))
-        (suppress-keymap map)
-        (set-keymap-parent map button-buffer-map)
-        map))
+(defvar geiser-doc-mode-map
+  (let ((map (make-sparse-keymap)))
+    (suppress-keymap map)
+    (set-keymap-parent map button-buffer-map)
+    map)
+  "Keymap for `geiser-doc-mode'.")
 
 (defun geiser-doc-switch-to-repl ()
   (interactive)

--- a/elisp/geiser-doc.el
+++ b/elisp/geiser-doc.el
@@ -314,17 +314,12 @@ help (e.g. browse an HTML page) implementing this method.")
   --
   ("Quit" nil View-quit))
 
-(defun geiser-doc-mode ()
+(define-derived-mode geiser-doc-mode nil "Geiser Doc"
   "Major mode for browsing scheme documentation.
 \\{geiser-doc-mode-map}"
-  (interactive)
-  (kill-all-local-variables)
   (buffer-disable-undo)
   (setq truncate-lines t)
-  (use-local-map geiser-doc-mode-map)
   (set-syntax-table scheme-mode-syntax-table)
-  (setq mode-name "Geiser Doc")
-  (setq major-mode 'geiser-doc-mode)
   (setq geiser-eval--get-module-function 'geiser-doc--module)
   (setq buffer-read-only t))
 

--- a/elisp/geiser-xref.el
+++ b/elisp/geiser-xref.el
@@ -46,18 +46,14 @@
   (let ((map (make-sparse-keymap)))
     (suppress-keymap map)
     (set-keymap-parent map button-buffer-map)
-    map))
+    map)
+  "Keymap for `geiser-xref-mode'.")
 
-(defun geiser-xref-mode ()
+(define-derived-mode geiser-xref-mode nil "Geiser Xref"
   "Major mode for displaying cross-references.
 \\{geiser-xref-mode-map}"
-  (interactive)
-  (kill-all-local-variables)
   (buffer-disable-undo)
-  (use-local-map geiser-xref-mode-map)
   (set-syntax-table scheme-mode-syntax-table)
-  (setq mode-name "Geiser Xref")
-  (setq major-mode 'geiser-xref-mode)
   (setq buffer-read-only t))
 
 


### PR DESCRIPTION
Hello again.  I think it's better to use `define-derived-mode` macro to
define modes, WDYT?

Or should I merge it into a single commit?