### PR TITLE
"M-x geiser-restart-repl" may not work in a live REPL

### DIFF
--- a/elisp/geiser-repl.el
+++ b/elisp/geiser-repl.el
@@ -788,23 +788,22 @@ over a Unix-domain socket."
 (defun switch-to-geiser (&optional ask impl buffer)
   "Switch to running Geiser REPL.
 
+If REPL is the current buffer, switch to the previously used
+scheme buffer.
+
 With prefix argument, ask for which one if more than one is running.
 If no REPL is running, execute `run-geiser' to start a fresh one."
   (interactive "P")
   (let* ((impl (or impl geiser-impl--implementation))
          (in-repl (eq major-mode 'geiser-repl-mode))
          (in-live-repl (and in-repl (get-buffer-process (current-buffer))))
-         (repl (cond ((and (not ask)
-                           (not impl)
-                           (not in-repl)
-                           (or geiser-repl--repl (car geiser-repl--repls))))
-                     ((and (not ask)
-                           (not in-repl)
-                           impl
-                           (geiser-repl--repl/impl impl))))))
-    (cond ((or in-live-repl
-               (and (eq (current-buffer) repl) (not (eq repl buffer))))
-           (when (buffer-live-p geiser-repl--last-scm-buffer)
+         (repl (unless ask
+                 (if impl
+                     (geiser-repl--repl/impl impl)
+                   (or geiser-repl--repl (car geiser-repl--repls))))))
+    (cond (in-live-repl
+           (when (and (not (eq repl buffer))
+                      (buffer-live-p geiser-repl--last-scm-buffer))
              (geiser-repl--switch-to-buffer geiser-repl--last-scm-buffer)))
           (repl (geiser-repl--switch-to-buffer repl))
           ((geiser-repl--remote-p)


### PR DESCRIPTION
As reported by manumanumanu on #geiser, ``M-x geiser-restart-repl`` may
not work when called from a live REPL.  Recipe to reproduce:

1. ``emacs -Q -l "<geiser>/elisp/geiser-load"``

2. Make a scheme buffer:

   - `C-x b tmp`
   - `M-x scheme-mode` (I used 'guile' implementation)

3. Start the REPL: `C-c C-z`

4. Restart the REPL: ``M-x geiser-restart-repl``

And instead of restarting, the point moves to "tmp" buffer and you get
the following error message:

    Current buffer has no process

This happens because `geiser-restart-repl` at first calls
`geiser-mode-switch-to-repl`, which calls `switch-to-geiser`, but
`switch-to-geiser` displays the previous scheme buffer in this case.

This commit fixes this issue: `switch-to-geiser` stays in the REPL when
we are trying to switch from it to the same REPL.
