### PR TITLE
Add MIT/GNU, Chez and Chibi to docs

### DIFF
--- a/doc/install.texi
+++ b/doc/install.texi
@@ -26,9 +26,17 @@ namely:
 better
 @item
 @uref{http://call-cc.org, Chicken} @value{CHICKEN_VERSION} or better
+@item
+@uref{https://www.gnu.org/software/mit-scheme/, MIT/GNU Scheme}
+@value{MIT_VERSION} or better
+@item
+@uref{http://synthcode.com/scheme/chibi/, Chibi Scheme}
+@value{CHIBI_VERSION} or better
+@item
+@uref{http://www.scheme.com, Chez Scheme} @value{CHEZ_VERSION} or better
 @end itemize
 
-Since Geiser supports multiple REPLs, having both of them will just add
+Since Geiser supports multiple REPLs, having all of them will just add
 to the fun.
 
 You'll also need Geiser itself.  The quickest installation is via its
@@ -135,8 +143,8 @@ code.  I'll follow you into its directory and the next section.
 Geiser is ready to be used out of the box without much more ado.  For the
 sake of concreteness, let's assume you put its source in the directory
 @file{~/lisp/geiser}.  All you need to do is to add the following
-line to your Emacs initialisation file (be it @file{~/.emacs} or any of
-its moral equivalents):
+line to your Emacs initialisation file (be it @file{~/.emacs},
+@file{~/.emacs.d/init.el} or any of its moral equivalents):
 
 @example
 (load-file "~/lisp/geiser/elisp/geiser.el")
@@ -205,7 +213,7 @@ $ sudo make install
 @end example
 
 With the above spell, Geiser will be compiled and installed in a safe
-place inside Emacs load path.  To load it into Emacs you'll need,
+place inside Emacs' load path.  To load it into Emacs you'll need,
 @i{instead} of the @code{load-file} form above, the following line in
 your initialisation file:
 

--- a/doc/macros.texi
+++ b/doc/macros.texi
@@ -4,6 +4,9 @@
 @set GUILE_VERSION 2.0.9
 @set RACKET_VERSION 6.0
 @set CHICKEN_VERSION 4.8.0
+@set MIT_VERSION 9.2.1
+@set CHIBI_VERSION 0.7.3
+@set CHEZ_VERSION 9.4
 @set EMACS_VERSION 23.2
 @set DOWN_BASE http://download-mirror.savannah.gnu.org/@/releases/@/geiser
 @set PACKAGE_REPO @value{DOWN_BASE}/@/packages

--- a/doc/repl.texi
+++ b/doc/repl.texi
@@ -326,8 +326,8 @@ some related tips.
 @subsubheading Choosing a Scheme implementation
 @cindex scheme implementation, choosing
 @anchor{choosing-impl}
-Instead of using the generic @command{run-geiser} command, you can start
-directly your Scheme of choice one of the following:
+Instead of using the generic @command{run-geiser} command, you can directly
+start your Scheme of choice using any of the following commands:
 @itemize @bullet
 @item @command{run-racket}
 @item @command{run-guile}

--- a/doc/repl.texi
+++ b/doc/repl.texi
@@ -21,16 +21,16 @@ ready, just come back here and proceed to the following sections.
 @cindex REPL
 To start a Scheme REPL (meaning, a Scheme process offering you a
 Read-Eval-Print Loop), Geiser provides the generic interactive command
-@command{run-geiser}.  If you invoke it (via, as is customary in Emacs,
+@command{run-geiser}. If you invoke it (via, as is customary in Emacs,
 @kbd{M-x run-geiser}), you'll be saluted by a prompt asking which one of
 the supported implementations you want to launch---yes, you can stop the
-asking, see
-@altr{active-implementations,below,Customization and tips,.}
-Tabbing for completion will offer you, as of this writing, @code{guile}
-and @code{racket}.  Just choose your poison, and a new REPL buffer will
-pop up (by default, the REPL will appear in a new window: if that annoys
-you, just set @code{geiser-repl-use-other-window} to @code{nil} and the
-current window will be used).
+asking, see @altr{active-implementations,below,Customization and tips,.}
+Tabbing for completion will offer you, as of this writing, @code{guile},
+@code{racket}, @code{chicken}, @code{mit}, @code{chibi} and @code{chez}.
+Just choose your poison, and a new REPL buffer will pop up (by default,
+the REPL will appear in a new window: if that annoys you, just set
+@code{geiser-repl-use-other-window} to @code{nil} and the current window
+will be used).
 
 @imgc{repls}
 
@@ -58,7 +58,7 @@ restart the REPL.
 If you're not happy with the faces Geiser is using for the REPL's prompt
 and evaluated input, you can customise
 @code{geiser-font-lock-repl-prompt} and
-@code{geiser-font-lock-repl-input} to better looking faces.
+@code{geiser-font-lock-repl-input} to better-looking faces.
 
 @subsubheading Connecting to an external Scheme
 @cindex remote REPL
@@ -327,8 +327,16 @@ some related tips.
 @cindex scheme implementation, choosing
 @anchor{choosing-impl}
 Instead of using the generic @command{run-geiser} command, you can start
-directly your Scheme of choice via @command{run-racket} or
-@command{run-guile}.  @anchor{active-implementations} In addition, the
+directly your Scheme of choice one of the following:
+@itemize @bullet
+@item @command{run-racket}
+@item @command{run-guile}
+@item @command{run-chicken}
+@item @command{run-mit}
+@item @command{run-chibi}
+@item @command{run-chez}
+@end itemize
+  @anchor{active-implementations} In addition, the
 variable @code{geiser-active-implementations} contains a list of those
 Schemes Geiser should be aware of.  Thus, if you happen to be, say, a
 racketeer not to be beguiled by other schemes, you can tell Geiser to
@@ -345,9 +353,16 @@ in your initialisation files.
 @cindex scheme executable path
 @anchor{impl-binary} When starting a new REPL, Geiser assumes, by
 default, that the corresponding Scheme binary is in your path.  If that's
-not the case, the variables to tweak are @code{geiser-guile-binary} and
-@code{geiser-racket-binary}, which should be set to a string with the
-full path to the requisite binary.
+not the case, the variables to tweak are (depending on which Scheme you choose):
+@itemize @bullet
+@item @code{geiser-guile-binary}
+@item @code{geiser-racket-binary}
+@item @code{geiser-chicken-binary}
+@item @code{geiser-mit-binary}
+@item @code{geiser-chibi-binary}
+@item @code{geiser-chez-binary}
+@end itemize
+They should be set to a string with the full path to the requisite binary.
 
 @cindex Version checking
 Before starting the REPL, Geiser will check wether the version of your
@@ -430,11 +445,12 @@ back, on a per-REPL basis, using @kbd{C-c C-d C-a}.
 
 @cindex port, default
 @cindex host, default
-When using @code{connect-to-guile}, @code{connect-to-racket} or
-@code{geiser-connect}, you'll be prompted for a host and a port,
-defaulting to ``localhost'' and 37146.  You can change those defaults
-customizing @code{geiser-repl-default-host} and
-@code{geiser-repl-default-port}, respectively.
+When using any of the connection commands (e.g. @code{geiser-connect},
+@code{connect-to-guile}, @code{connect-to-racket}, etc.) you'll be
+prompted for a host and a port, defaulting to ``localhost'' and 37146.
+You can change those defaults customizing
+@code{geiser-repl-default-host} and @code{geiser-repl-default-port},
+respectively.
 
 @subsubheading Killing REPLs
 


### PR DESCRIPTION
Just fixed in a few places, maybe implementation-specific parts should be moved to a separate chapter, with sections for each implementation?