### PR TITLE
geiser-chibi: Implement autodoc for procedures in known modules

### DIFF
--- a/scheme/chibi/geiser/geiser.sld
+++ b/scheme/chibi/geiser/geiser.sld
@@ -5,5 +5,5 @@
           geiser:module-completions
           geiser:no-values
           geiser:newline)
-  (import (scheme small) (chibi modules) (chibi) (meta) (chibi string) (srfi 1) (srfi 95))
+  (import (scheme small) (chibi modules) (chibi) (meta) (chibi ast) (chibi string) (srfi 1) (srfi 95))
   (include "geiser.scm"))


### PR DESCRIPTION
This commit implements autodoc for procedures (not opcodes) in procedures in known modules. It does not work (yet) for procedures defined at the repl.