### PR TITLE
NEW add option to not jump to popup buffer

### DIFF
--- a/elisp/geiser-popup.el
+++ b/elisp/geiser-popup.el
@@ -15,6 +15,7 @@
 ;;; Support for defining popup buffers and accessors:
 
 (defvar geiser-popup--registry nil)
+(defvar geiser-popup--no-jump nil)
 
 (defvar geiser-popup--overriding-map
   (let ((map (make-sparse-keymap)))
@@ -48,7 +49,8 @@
      (defun ,pop-buff (&optional ,method)
        (let ((,buffer (funcall ',get-buff)))
          (unless (eq ,buffer (current-buffer))
-           (cond ((eq ,method 'buffer) (view-buffer ,buffer))
+           (cond (geiser-popup--no-jump (display-buffer ,buffer))
+                 ((eq ,method 'buffer) (view-buffer ,buffer))
                  ((eq ,method 'frame) (view-buffer-other-frame ,buffer))
                  (t (view-buffer-other-window ,buffer))))))
      (defmacro ,with-macro (&rest body)


### PR DESCRIPTION
Every time you evaluate a scheme expression your cursor jumps to the `*Geiser dbg*` buffer. I added an option that will stop the jumping of your cursor while still opening the buffer in a new window.

I am not sure if this behavior was already achievable in another way but I could not find it. If there is such a way please enlighten me.