### PR TITLE
Expand socket file name for 'geiser-connect-local'

### DIFF
--- a/elisp/geiser-repl.el
+++ b/elisp/geiser-repl.el
@@ -774,7 +774,7 @@ buffer."
 over a Unix-domain socket."
   (interactive
    (list (geiser-repl--get-impl "Connect to Scheme implementation: ")
-         (read-file-name "Socket file name: ")))
+         (expand-file-name (read-file-name "Socket file name: "))))
   (let ((buffer (current-buffer)))
     (geiser-repl--start-repl impl socket)
     (geiser-repl--maybe-remember-scm-buffer buffer)))


### PR DESCRIPTION
Hello, ``M-x geiser-connect-local`` uses `read-file-name` while
prompting for a socket file name, however this name is not expanded
(look at `C-h f read-file-name`), so the connection may fail.

To reproduce the bug try this recipe:

1. guile --listen=$HOME/tmp-guile-socket

2. ``emacs -Q -l "<geiser>/elisp/geiser-load"``

3. ``M-x geiser-connect-local``
   Choose implementation `guile` and socket `~/tmp-guile-socket`.

And instead of connecting there is the following error:

    Unable to start REPL:
    make client process failed: no such file or directory, :name, * Guile REPL *, :buffer, * Guile REPL *, :family, local, :remote, ~/tmp-guile-socket

This PR fixes it.