### PR TITLE
Use (car (process-lines ...)) instead of (shell-command ...)

### DIFF
--- a/elisp/geiser-chez.el
+++ b/elisp/geiser-chez.el
@@ -96,9 +96,7 @@ This function uses `geiser-chez-init-file' if it exists."
 (defconst geiser-chez-minimum-version "9.4")
 
 (defun geiser-chez--version (binary)
-  (shell-command-to-string
-   (format "%s --version"
-           (shell-quote-argument binary))))
+  (car (process-lines binary "--version")))
 
 (defun geiser-chez--startup (remote)
   (let ((geiser-log-verbose-p t))

--- a/elisp/geiser-chibi.el
+++ b/elisp/geiser-chibi.el
@@ -97,10 +97,9 @@ This function uses `geiser-chibi-init-file' if it exists."
 (defconst geiser-chibi-minimum-version "0.7.3")
 
 (defun geiser-chibi--version (binary)
-  (second (split-string (shell-command-to-string
-                         (format "%s -V"
-                                 (shell-quote-argument binary)))
-                        " ")))
+  (second (split-string
+           (car (process-lines binary "-V"))
+           " ")))
 
 (defun geiser-chibi--startup (remote)
   (let ((geiser-log-verbose-p t))

--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -258,10 +258,7 @@ This function uses `geiser-chicken-init-file' if it exists."
 (defconst geiser-chicken-minimum-version "4.8.0.0")
 
 (defun geiser-chicken--version (binary)
-  (shell-command-to-string
-   (format "%s -e %s"
-           (shell-quote-argument binary)
-           (shell-quote-argument "(display (chicken-version))"))))
+  (car (process-lines binary "-e" "(display (chicken-version))")))
 
 (defun connect-to-chicken ()
   "Start a Chicken REPL connected to a remote process."

--- a/elisp/geiser-guile.el
+++ b/elisp/geiser-guile.el
@@ -334,10 +334,7 @@ This function uses `geiser-guile-init-file' if it exists."
 (defconst geiser-guile-minimum-version "2.0")
 
 (defun geiser-guile--version (binary)
-  (shell-command-to-string
-   (format "%s  -c %s"
-           (shell-quote-argument binary)
-           (shell-quote-argument "(display (version))"))))
+  (car (process-lines binary "-c" "(display (version))")))
 
 (defun geiser-guile-update-warning-level ()
   "Update the warning level used by the REPL.

--- a/elisp/geiser-mit.el
+++ b/elisp/geiser-mit.el
@@ -120,10 +120,12 @@ This function uses `geiser-mit-init-file' if it exists."
 (defconst geiser-mit-minimum-version "9.1.1")
 
 (defun geiser-mit--version (binary)
-  (shell-command-to-string
-   (format "%s --quiet --no-init-file --eval %s"
-           (shell-quote-argument binary)
-           "'(begin (display (get-subsystem-version-string \"Release\")) (%exit 0))'")))
+  (car (process-lines binary
+                      "--quiet"
+                      "--no-init-file"
+                      "--eval"
+                      "(begin (display (get-subsystem-version-string \"Release\"))
+                              (%exit 0))")))
 
 (defconst geiser-mit--path-rx "^In \\([^:\n ]+\\):\n")
 (defun geiser-mit--startup (remote)

--- a/elisp/geiser-racket.el
+++ b/elisp/geiser-racket.el
@@ -363,10 +363,7 @@ using start-geiser, a procedure in the geiser/server module."
 (defvar geiser-racket-minimum-version "5.3")
 
 (defun geiser-racket--version (binary)
-  (shell-command-to-string
-   (format "%s  -e %s"
-           (shell-quote-argument binary)
-           (shell-quote-argument "(display (version))"))))
+  (car (process-lines binary "-e" "(display (version))")))
 
 (defvar geiser-racket--image-cache-dir nil)
 


### PR DESCRIPTION
`shell-command` assumes Bourne-shell-compatible quoting, which doesn't work when the user isn't using a Bourne-compatible shell. Instead of futzing about with quoting, we can just use `process-lines` to execute a process and pass it arguments directly.

-------------

*Scenario*: I use [rc](https://github.com/rakitzis/rc) as my main shell, which doesn't treat double-quotes specially or use backslashes for escaping characters. It isn't possible for me to run `geiser` without this patch.