### PR TITLE
fix malformed argument lists.

### DIFF
--- a/elisp/geiser-eval.el
+++ b/elisp/geiser-eval.el
@@ -29,7 +29,7 @@
 
 (defvar geiser-eval--get-impl-module nil)
 (geiser-impl--register-local-method
- 'geiser-eval--get-impl-module 'find-module '(lambda (&rest) nil)
+ 'geiser-eval--get-impl-module 'find-module '(lambda (&rest args) nil)
  "Function used to obtain the module for current buffer. It takes
 an optional argument, for cases where we want to force its
 value.")

--- a/elisp/geiser-impl.el
+++ b/elisp/geiser-impl.el
@@ -158,7 +158,7 @@ determine its scheme flavour."
              (= 2 (length m))
              (symbolp (car m)))
     (if (functionp (cadr m)) m
-      `(,(car m) (lambda (&rest) ,(cadr m))))))
+      `(,(car m) (lambda (&rest args) ,(cadr m))))))
 
 (defun geiser-impl--define (file name parent methods)
   (let* ((methods (mapcar 'geiser-impl--normalize-method methods))


### PR DESCRIPTION
Emacs trunk does not support arguments list like (lambda (&rest) nil)
anymore, which breaks geiser and errors with "Invalid function: "