### PR TITLE
Handle exceptions of ChezScheme and multi-value as well

### DIFF
--- a/scheme/chez/geiser/geiser.ss
+++ b/scheme/chez/geiser/geiser.ss
@@ -30,11 +30,34 @@
 
   (define (geiser:eval module form . rest)
     rest
-    (let ((result (if module
-                      (eval form (environment module))
-                      (eval form))))
+    (let* ((try-eval (lambda (x . y)
+		       (call/cc
+			(lambda (k)
+			  (with-exception-handler
+			      (lambda (e)
+				(k e))
+			    (lambda () 
+				    (if (null? y) (eval x)
+					(eval x (car y)))
+				    ))))))
+	   (result-mid (call-with-values
+			   (lambda () (if module
+					  (try-eval form (environment module))
+					  (try-eval form)))
+			 (lambda (x . y)
+			   (if (null? y)
+			       x
+			       (cons x y)))))
+	   (result result-mid)
+	   (error (if (condition? result-mid)
+		      (cons 'error (list
+				    (cons 'key
+					  (with-output-to-string
+					    (lambda () (display-condition result-mid))))))
+		      '())))
       (write `((result ,(write-to-string result))
-               (output . "")))
+               (output . "")
+	       ,error))
       (newline)))
 
   (define (geiser:module-completions prefix . rest)

--- a/scheme/chez/geiser/geiser.ss
+++ b/scheme/chez/geiser/geiser.ss
@@ -55,7 +55,9 @@
 					  (with-output-to-string
 					    (lambda () (display-condition result-mid))))))
 		      '())))
-      (write `((result ,(write-to-string result))
+      (write `((result ,(with-output-to-string
+			  (lambda ()
+			    (pretty-print result))))
                (output . "")
 	       ,error))
       (newline)))

--- a/scheme/chez/geiser/test.ss
+++ b/scheme/chez/geiser/test.ss
@@ -1,0 +1,90 @@
+(import (geiser)
+	(chezscheme))
+
+
+(define-syntax get-result
+  (syntax-rules ()
+    ((_ form)
+     (with-output-to-string
+       (lambda ()
+	 (geiser:eval #f form))))))
+
+(define-syntax do-test
+  (syntax-rules ()
+    ((_ form result)
+     (assert
+      (equal?
+       (get-result form)
+       result)))))
+
+;; (something-doesnot-exist)
+;;=> Error: Exception: variable something-doesnot-exist is not bound
+(do-test
+ '(something-doesnot-exist)
+ "((result \"\") (output . \"\") (error (key . \"Exception: variable something-doesnot-exist is not bound\")))\n"
+ )
+
+;; (make-violation)
+;;=> #<condition &violation>
+(do-test
+ '(make-violation) 
+ "((result \"#<condition &violation>\\n\") (output . \"\"))\n")
+
+;; (values 1 2 3)
+;;==> (1 2 3)
+(do-test
+ '(values 1 2 3)
+ "((result \"(1 2 3)\\n\") (output . \"\"))\n")
+
+;; 1
+;;=> 1
+(do-test '1 "((result \"1\\n\") (output . \"\"))\n")
+
+
+;; '(case-lambda
+;;    [(x1 x2) (+ x1 x2)]
+;;    [(x1 x2 x3) (+ (+ x1 x2) x3)]
+;;    [(x1 x2 . rest)
+;;     ((letrec ([loop (lambda (x1 x2 rest)
+;; 		      (let ([x (+ x1 x2)])
+;; 			(if (null? rest)
+;; 			    x
+;; 			    (loop x (car rest) (cdr rest)))))])
+;;        loop)
+;;      x1
+;;      x2
+;;      rest)]
+;;    [(x1) (+ x1)]
+;;    [() (+)])
+#|=> (case-lambda
+  [(x1 x2) (+ x1 x2)]
+  [(x1 x2 x3) (+ (+ x1 x2) x3)]
+  [(x1 x2 . rest)
+   ((letrec ([loop (lambda (x1 x2 rest)
+                     (let ([x (+ x1 x2)])
+                       (if (null? rest)
+                           x
+                           (loop x (car rest) (cdr rest)))))])
+      loop)
+     x1
+     x2
+     rest)]
+  [(x1) (+ x1)]
+  [() (+)])
+  |#
+(do-test (quote '(case-lambda
+  [(x1 x2) (+ x1 x2)]
+  [(x1 x2 x3) (+ (+ x1 x2) x3)]
+  [(x1 x2 . rest)
+   ((letrec ([loop (lambda (x1 x2 rest)
+                     (let ([x (+ x1 x2)])
+                       (if (null? rest)
+                           x
+                           (loop x (car rest) (cdr rest)))))])
+      loop)
+     x1
+     x2
+     rest)]
+  [(x1) (+ x1)]
+  [() (+)])) "((result \"(case-lambda\\n  [(x1 x2) (+ x1 x2)]\\n  [(x1 x2 x3) (+ (+ x1 x2) x3)]\\n  [(x1 x2 . rest)\\n   ((letrec ([loop (lambda (x1 x2 rest)\\n                     (let ([x (+ x1 x2)])\\n                       (if (null? rest)\\n                           x\\n                           (loop x (car rest) (cdr rest)))))])\\n      loop)\\n     x1\\n     x2\\n     rest)]\\n  [(x1) (+ x1)]\\n  [() (+)])\\n\") (output . \"\"))\n")
+


### PR DESCRIPTION
- Capture exceptions of ChezScheme
- handles multi-value return

Example:
`
(some-procedure-does-not-exists)
;;=>ERROR:Error: Exception: variable some-procedure-does-not-exists is not bound

(values 1 2 3)
;;=>(1 2 3)

(+ 1 1)
;;=>2
`