### PR TITLE
Add geiser-mode-eval-to-buffer-transformer

### DIFF
--- a/elisp/geiser-mode.el
+++ b/elisp/geiser-mode.el
@@ -72,6 +72,11 @@ active when `geiser-mode' is activated in a buffer."
   :group 'geiser-mode
   :type 'string)
 
+(geiser-custom--defcustom geiser-mode-eval-to-buffer-transformer '()
+  "When `geiser-mode-eval-last-sexp-to-buffer', the prefix string which will prepend to results"
+  :group 'geiser-mode
+  :type 'list)
+
 
 
 ;;; Evaluation commands:
@@ -161,12 +166,20 @@ With a prefix, revert the effect of `geiser-mode-eval-last-sexp-to-buffer' "
 				geiser-mode-eval-last-sexp-to-buffer))
 	 (str (geiser-eval--retort-result-str ret (when will-eval-to-buffer ""))))
     (cond  ((not will-eval-to-buffer) str)
-	   (err (insert (format "%sERROR:%s"
-                                geiser-mode-eval-to-buffer-prefix
-                                (geiser-eval--error-str err))))
+	   (err (insert
+		 (if geiser-mode-eval-to-buffer-transformer
+		     (funcall geiser-mode-eval-to-buffer-transformer
+			      "ERROR:"
+			      (geiser-eval--error-str err))
+		   (format "%sERROR:%s"
+			   geiser-mode-eval-to-buffer-prefix
+			   (geiser-eval--error-str err)))))
 	   ((string= "" str))
 	   (t (push-mark)
-              (insert (format "%s%s" geiser-mode-eval-to-buffer-prefix str))))))
+              (insert (if geiser-mode-eval-to-buffer-transformer
+			  (funcall geiser-mode-eval-to-buffer-transformer ""
+				   str)
+			(format "%s%s" geiser-mode-eval-to-buffer-prefix str)))))))
 
 (defun geiser-compile-definition (&optional and-go)
   "Compile the current definition in the Geiser REPL.

--- a/elisp/geiser-mode.el
+++ b/elisp/geiser-mode.el
@@ -72,10 +72,15 @@ active when `geiser-mode' is activated in a buffer."
   :group 'geiser-mode
   :type 'string)
 
-(geiser-custom--defcustom geiser-mode-eval-to-buffer-transformer '()
-  "When `geiser-mode-eval-last-sexp-to-buffer', the prefix string which will prepend to results"
+(geiser-custom--defcustom geiser-mode-eval-to-buffer-transformer nil
+  "When `geiser-mode-eval-last-sexp-to-buffer', the result will be transformed using this function
+default behavior is just prepend with `geiser-mode-eval-to-buffer-prefix'
+takes two arguments: `msg' and `is-error?' 
+`msg' is the result string going to be transformed, 
+`is-error?' is a bool indicate whether the result is an error msg 
+"
   :group 'geiser-mode
-  :type 'list)
+  :type 'function)
 
 
 
@@ -154,6 +159,10 @@ With a prefix, revert the effect of `geiser-mode-eval-last-sexp-to-buffer' "
                                  (setq bosexp (point))
                                  (forward-sexp)
                                  (point)))
+	 (ret-transformer (or geiser-mode-eval-to-buffer-transformer
+			      (lambda (msg is-error?)
+				(format "%s%s%s" geiser-mode-eval-to-buffer-prefix
+					(if is-error? "ERROR" "") msg))))
          (ret (save-excursion
                 (geiser-eval-region bosexp ;beginning of sexp
                                     eosexp ;end of sexp
@@ -166,20 +175,10 @@ With a prefix, revert the effect of `geiser-mode-eval-last-sexp-to-buffer' "
 				geiser-mode-eval-last-sexp-to-buffer))
 	 (str (geiser-eval--retort-result-str ret (when will-eval-to-buffer ""))))
     (cond  ((not will-eval-to-buffer) str)
-	   (err (insert
-		 (if geiser-mode-eval-to-buffer-transformer
-		     (funcall geiser-mode-eval-to-buffer-transformer
-			      "ERROR:"
-			      (geiser-eval--error-str err))
-		   (format "%sERROR:%s"
-			   geiser-mode-eval-to-buffer-prefix
-			   (geiser-eval--error-str err)))))
+	   (err (insert (funcall ret-transformer err t)))
 	   ((string= "" str))
 	   (t (push-mark)
-              (insert (if geiser-mode-eval-to-buffer-transformer
-			  (funcall geiser-mode-eval-to-buffer-transformer ""
-				   str)
-			(format "%s%s" geiser-mode-eval-to-buffer-prefix str)))))))
+              (insert (funcall ret-transformer str nil))))))
 
 (defun geiser-compile-definition (&optional and-go)
   "Compile the current definition in the Geiser REPL.

--- a/elisp/geiser-mode.el
+++ b/elisp/geiser-mode.el
@@ -175,7 +175,7 @@ With a prefix, revert the effect of `geiser-mode-eval-last-sexp-to-buffer' "
 				geiser-mode-eval-last-sexp-to-buffer))
 	 (str (geiser-eval--retort-result-str ret (when will-eval-to-buffer ""))))
     (cond  ((not will-eval-to-buffer) str)
-	   (err (insert (funcall ret-transformer err t)))
+	   (err (insert (funcall ret-transformer (geiser-eval--error-str err) t)))
 	   ((string= "" str))
 	   (t (push-mark)
               (insert (funcall ret-transformer str nil))))))


### PR DESCRIPTION
geiser-mode-eval-to-buffer-transformer will take 2 argments:
errstring and result
when eval-to-buffer, the result will be transformed by this procedure
e.g.
(setq geiser-mode-eval-to-buffer-transformer
      (lambda (estring x)
	(let ((l (length x))
	      (p (seq-position x ?\n)))
	  (if (and p (< (+ 1 p) l))
	      (format "\n#| %s%s\n  |#" estring x)
	    (format ";;=> %s%s" estring x)))))