### PR TITLE
simple geiser-chez--display-error

### DIFF
--- a/elisp/geiser-chez.el
+++ b/elisp/geiser-chez.el
@@ -102,6 +102,9 @@ This function uses `geiser-chez-init-file' if it exists."
   (let ((geiser-log-verbose-p t))
     (compilation-setup t)
     (geiser-eval--send/wait "(begin (import (geiser)) (write `((result ) (output . \"\"))) (newline))")))
+
+(defun geiser-chez--display-error (module key msg)
+  (and key (message key) nil))
 
 ;;; Implementation definition:
 
@@ -120,7 +123,7 @@ This function uses `geiser-chez-init-file' if it exists."
   (exit-command geiser-chez--exit-command)
   (import-command geiser-chez--import-command)
   (find-symbol-begin geiser-chez--symbol-begin)
-  ;; (display-error geiser-chez--display-error)
+  (display-error geiser-chez--display-error)
   ;; (external-help geiser-chez--manual-look-up)
   ;; (check-buffer geiser-chez--guess)
   ;; (keywords geiser-chez--keywords)


### PR DESCRIPTION
Add a simple implementation of geiser-chez--display-error witch always returning `ni'l to avoid create a debug window.
After investigation on `geiser-debug--display-retort', I think this is enough to fix #219 . So I submit this PR.