### PR TITLE
Do not set geiser last-prompt-end beyond of point-max

### DIFF
--- a/elisp/geiser-repl.el
+++ b/elisp/geiser-repl.el
@@ -303,7 +303,9 @@ module command as a string")
          (marker-position (cdr comint-last-prompt)))
         ((and (boundp 'comint-last-prompt-overlay) comint-last-prompt-overlay)
          (overlay-end comint-last-prompt-overlay))
-        (t (save-excursion (geiser-repl--bol) (+ 1 (point))))))
+        (t (save-excursion
+             (geiser-repl--bol)
+             (min (+ 1 (point)) (point-max))))))
 
 (defun geiser-repl--last-prompt-start ()
   (cond ((and (boundp 'comint-last-prompt) (markerp (car comint-last-prompt)))


### PR DESCRIPTION
Various functions use `geiser-repl--last-prompt-end` to get the but
the but the end of last prompt, but we must ensure that does not goes beyond `point-max`.

### Scenario

1. Start a repl, e.g `run-chez`
2. In the repl, enter a comma (<kbd>,</kbd>) and <kbd>Enter</kbd> twice:

   ```
   Debugger entered--Lisp error: (args-out-of-range 70 71)
     geiser-repl--nesting-level()
     geiser-repl--maybe-send()
     funcall-interactively(geiser-repl--maybe-send)
     call-interactively(geiser-repl--maybe-send nil nil)
     command-execute(geiser-repl--maybe-send)
   ```
    which makes the repl unusable, this happens because `geiser-repl--maybe-send` uses `geiser-repl--nesting-level` which tries to narrow from `last-prompt-end` to `point-max`, but `last-prompt-end` is beyond `point-max` so throws that error.
