### PR TITLE
Don't associate .rkt with scheme-mode

### DIFF
--- a/elisp/geiser.el
+++ b/elisp/geiser.el
@@ -159,8 +159,6 @@
 
 ;;;###autoload
 (add-hook 'scheme-mode-hook 'geiser-mode--maybe-activate)
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.rkt\\'" . scheme-mode))
 
 
 (provide 'geiser)


### PR DESCRIPTION
This interferes with the autoload set up by racket-mode.

I think this is something that users should opt-in to. Otherwise, if a user has scheme-mode, racket-mode and geiser all installed, it's not obvious why foo.rkt is opened in scheme-mode.