### PR TITLE
Tinyscheme

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ elpa: README.elpa info
 	$(mkdir_p) $(scheme_dir)/chicken/geiser
 	$(mkdir_p) $(scheme_dir)/chibi/geiser
 	$(mkdir_p) $(scheme_dir)/mit/geiser
+	$(mkdir_p) $(scheme_dir)/tiny/geiser
 	$(INSTALL_DATA) $(abs_top_srcdir)/scheme/chez/geiser/* \
                         $(scheme_dir)/chez/geiser
 	$(INSTALL_DATA) $(abs_top_srcdir)/scheme/guile/geiser/* \
@@ -40,6 +41,8 @@ elpa: README.elpa info
                         $(scheme_dir)/chicken/geiser
 	$(INSTALL_DATA) $(abs_top_srcdir)/scheme/mit/geiser/* \
                         $(scheme_dir)/mit/geiser
+	$(INSTALL_DATA) $(abs_top_srcdir)/scheme/tiny/geiser/* \
+                        $(scheme_dir)/tiny/geiser
 
 	$(INSTALL_DATA) $(srcdir)/doc/geiser.info $(elpa_dir)
 	(cd $(elpa_dir) && install-info --dir=dir geiser.info 2>/dev/null)

--- a/elisp/Makefile.am
+++ b/elisp/Makefile.am
@@ -28,6 +28,7 @@ dist_lisp_LISP = \
    geiser-reload.el \
    geiser-repl.el \
    geiser-syntax.el \
+   geiser-tiny.el \
    geiser-xref.el \
    geiser-version.el
 

--- a/elisp/geiser-impl.el
+++ b/elisp/geiser-impl.el
@@ -29,7 +29,7 @@
   :group 'geiser-implementation)
 
 (geiser-custom--defcustom geiser-active-implementations
-    '(guile racket chicken chez mit chibi)
+    '(guile racket chicken chez mit chibi tiny)
   "List of active installed Scheme implementations."
   :type '(repeat symbol)
   :group 'geiser-implementation)

--- a/elisp/geiser-tiny.el
+++ b/elisp/geiser-tiny.el
@@ -59,7 +59,7 @@ This function uses `geiser-tiny-init-file' if it exists."
            (module (cond ((string-equal "'()" (car args))
                           "'()")
                          ((and (car args))
-                             (concat "'" (car args)))
+			  (concat "'" (car args)))
                          (t
                           "#f"))))
        (format "(geiser:eval %s '%s)" module form)))
@@ -71,6 +71,7 @@ This function uses `geiser-tiny-init-file' if it exists."
      (let ((form (mapconcat 'identity args " ")))
        (format "(geiser:%s %s)" proc form)))))
 
+;; WSG: No real modules in Tinyscheme...
 (defun geiser-tiny--get-module (&optional module)
   (cond ((null module)
          :f)

--- a/elisp/geiser-tiny.el
+++ b/elisp/geiser-tiny.el
@@ -1,0 +1,143 @@
+;; geiser-tiny.el -- Tinyscheme's implementation of the geiser protocols
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the Modified BSD License. You should
+;; have received a copy of the license along with this program. If
+;; not, see <http://www.xfree86.org/3.3.6/COPYRIGHT2.html#5>.
+
+(require 'geiser-connection)
+(require 'geiser-syntax)
+(require 'geiser-custom)
+(require 'geiser-base)
+(require 'geiser-eval)
+(require 'geiser-edit)
+(require 'geiser-log)
+(require 'geiser)
+
+(require 'compile)
+(require 'info-look)
+
+(eval-when-compile (require 'cl))
+
+
+;;; Customization:
+
+(defgroup geiser-tiny nil
+  "Customization for Geiser's Tinyscheme flavour."
+  :group 'geiser)
+
+(geiser-custom--defcustom geiser-tiny-binary
+    "tinyscheme"
+  "Name to use to call the Tinyscheme executable when starting a REPL."
+  :type '(choice string (repeat string))
+  :group 'geiser-tiny)
+
+
+;;; REPL support:
+
+(defun geiser-tiny--binary ()
+  (if (listp geiser-tiny-binary)
+      (car geiser-tiny-binary)
+    geiser-tiny-binary))
+
+(defun geiser-tiny--parameters ()
+  "Return a list with all parameters needed to start Tinyscheme.
+This function uses `geiser-tiny-init-file' if it exists."
+  ;; `("-1" ,(expand-file-name "tiny/geiser/geiser.scm" geiser-scheme-dir))
+  nil
+  )
+
+(defconst geiser-tiny--prompt-regexp "ts> ")
+
+
+;;; Evaluation support:
+
+(defun geiser-tiny--geiser-procedure (proc &rest args)
+  (case proc
+    ((eval compile)
+     (let ((form (mapconcat 'identity (cdr args) " "))
+           (module (cond ((string-equal "'()" (car args))
+                          "'()")
+                         ((and (car args))
+                             (concat "'" (car args)))
+                         (t
+                          "#f"))))
+       (format "(geiser:eval %s '%s)" module form)))
+    ((load-file compile-file)
+     (format "(geiser:load-file %s)" (car args)))
+    ((no-values)
+     "(geiser:no-values)")
+    (t
+     (let ((form (mapconcat 'identity args " ")))
+       (format "(geiser:%s %s)" proc form)))))
+
+(defun geiser-tiny--get-module (&optional module)
+  (cond ((null module)
+         :f)
+        ((listp module) module)
+        ((stringp module)
+         (condition-case nil
+             (car (geiser-syntax--read-from-string module))
+           (error :f)))
+        (t :f)))
+
+(defun geiser-tiny--symbol-begin (module)
+  ;; (if module
+  ;;     (max (save-excursion (beginning-of-line) (point))
+  ;;          (save-excursion (skip-syntax-backward "^(>") (1- (point))))
+    (save-excursion (skip-syntax-backward "^'-()>") (point)))
+
+(defun geiser-tiny--import-command (module)
+  ;; (format "(import %s)" module)
+  ""
+  )
+
+(defun geiser-tiny--exit-command () "(quit 0)")
+;; 
+;; ;;; REPL startup
+
+(defconst geiser-tiny-minimum-version "1.31")
+
+(defun geiser-tiny--version (binary)
+  ;; (car (process-lines binary "--version"))
+  "1.31"
+  )
+
+(defun geiser-tiny--startup (remote)
+  (let ((geiser-log-verbose-p t))
+    (compilation-setup t)
+    ;; WSG: This is a hack around my not being able to load the file
+    ;; and then run the REPL. To be fixed in the future.
+    (geiser-eval--send/wait (format "(begin (load %S) (newline))"
+				    (expand-file-name
+				     "tiny/geiser/geiser.scm"
+				     geiser-scheme-dir)))
+    ))
+
+;;; Implementation definition:
+
+(define-geiser-implementation tiny
+  (binary geiser-tiny--binary)
+  (arglist geiser-tiny--parameters)
+  (version-command geiser-tiny--version)
+  (minimum-version geiser-tiny-minimum-version)
+  (repl-startup geiser-tiny--startup)
+  (prompt-regexp geiser-tiny--prompt-regexp)
+  (debugger-prompt-regexp nil) ;; geiser-chez--debugger-prompt-regexp
+  ;; (enter-debugger geiser-chez--enter-debugger)
+  (marshall-procedure geiser-tiny--geiser-procedure)
+  (find-module geiser-tiny--get-module)
+  ;; (enter-command geiser-chez--enter-command)
+  (exit-command geiser-tiny--exit-command)
+  (import-command geiser-tiny--import-command)
+  (find-symbol-begin geiser-tiny--symbol-begin)
+  ;; (display-error geiser-chez--display-error)
+  ;; (external-help geiser-chez--manual-look-up)
+  ;; (check-buffer geiser-chez--guess)
+  ;; (keywords geiser-chez--keywords)
+  ;; (case-sensitive geiser-chez-case-sensitive-p)
+  )
+
+(geiser-impl--add-to-alist 'regexp "\\.scm$" 'tiny t)
+
+(provide 'geiser-tiny)

--- a/elisp/geiser.el
+++ b/elisp/geiser.el
@@ -69,6 +69,13 @@
   "Start a Geiser Chez REPL, or switch to a running one." t)
 
 ;;;###autoload
+(autoload 'run-tiny "geiser-tiny" "Start a Tinyscheme REPL." t)
+
+;;;###autoload
+(autoload 'switch-to-tiny "geiser-tiny"
+  "Start a Tinyscheme REPL, or switch to a running one." t)
+
+;;;###autoload
 (autoload 'run-guile "geiser-guile" "Start a Geiser Guile REPL." t)
 
 ;;;###autoload
@@ -151,6 +158,7 @@
 	geiser-chez
 	geiser-chibi
 	geiser-mit
+	geiser-tiny
         geiser-implementation
         geiser-xref))
 

--- a/scheme/Makefile.am
+++ b/scheme/Makefile.am
@@ -25,5 +25,6 @@ nobase_dist_pkgdata_DATA = \
   mit/geiser/load.scm \
   mit/geiser/compile.scm \
   chez/geiser/geiser.ss \
+  tiny/geiser/geiser.scm \
   chibi/geiser/geiser.scm \
   chibi/geiser/geiser.sld

--- a/scheme/tiny/geiser/geiser.scm
+++ b/scheme/tiny/geiser/geiser.scm
@@ -52,16 +52,26 @@
     (lambda ()
       (write x))))
 
-(define (map f a b)
-  (let ((map2 #f))
-    (let ((tmp-map2
-            (lambda (a b)
+(define (map f a)
+  (let ((map1 #f))
+    (let ((tmp-map1
+            (lambda (a)
               (if (null? a)
                   '()
-                   (cons (f (car a) (car b))
-                         (map2 (cdr a) (cdr b)))))))
-    (set! map2 tmp-map2)
-    (map2 a b))))
+                   (cons (f (car a))
+                         (map1 (cdr a)))))))
+    (set! map1 tmp-map1)
+    (map1 a))))
+
+(define (geiser:eval module form . rest)
+    rest
+    (let ((output (open-output-string))
+	  (result (if module
+                      (eval form (environment module))
+                      (eval form))))
+      (write `((result ,(write-to-string result))
+               (output ,(get-output-string output))))
+      (newline)))
 
 (define (geiser:completions prefix . rest)
   rest

--- a/scheme/tiny/geiser/geiser.scm
+++ b/scheme/tiny/geiser/geiser.scm
@@ -52,9 +52,28 @@
     (lambda ()
       (write x))))
 
+(define (map f a b)
+  (let ((map2 #f))
+    (let ((tmp-map2
+            (lambda (a b)
+              (if (null? a)
+                  '()
+                   (cons (f (car a) (car b))
+                         (map2 (cdr a) (cdr b)))))))
+    (set! map2 tmp-map2)
+    (map2 a b))))
+
 (define (geiser:completions prefix . rest)
   rest
-  (sort string-ci<?
+  ;; WSG: Fix the string comparison problem
+  ;; (sort string-ci<?
         (filter (lambda (el)
                   (string-prefix? prefix el))
-                (map write-to-string (apply append (oblist))))))
+                (map write-to-string (apply append (oblist)))))
+;; )
+
+(define (geiser:no-values)
+  #f)
+
+(define (geiser:newline)
+  #f))

--- a/scheme/tiny/geiser/geiser.scm
+++ b/scheme/tiny/geiser/geiser.scm
@@ -1,3 +1,5 @@
+;; -*- geiser-scheme-implementation: tiny -*-
+
 (define string-prefix?
   (lambda (x y)
     (let ((n (string-length x)))

--- a/scheme/tiny/geiser/geiser.scm
+++ b/scheme/tiny/geiser/geiser.scm
@@ -1,0 +1,60 @@
+(define string-prefix?
+  (lambda (x y)
+    (let ((n (string-length x)))
+      (and (<= n (string-length y))
+           (let prefix? ((i 0))
+             (or (= i n)
+                 (and (char=? (string-ref x i) (string-ref y i))
+                      (prefix? (+ i 1)))))))))
+
+(define (split-by l p k)
+  (let loop ((low '())
+             (high '())
+             (l l))
+    (cond ((null? l)
+           (k low high))
+          ((p (car l))
+           (loop low (cons (car l) high) (cdr l)))
+          (else
+           (loop (cons (car l) low) high (cdr l))))))
+ 
+(define (sort f l)
+  (if (null? l)
+      '()
+      (split-by (cdr l) 
+                (lambda (x) (f (car l) x))
+                (lambda (low high)
+                  (append (sort f low)
+                          (list (car l))
+                          (sort f high))))))
+
+(define (filter pred lst)
+  (cond ((null? lst) '())
+        ((pred (car lst))
+         (cons (car lst) (filter pred (cdr lst))))
+        (else (filter pred (cdr lst)))))
+
+(define (call-with-output-string proc)
+  (let ((out (open-output-string)))
+    (proc out)
+    (get-output-string out)))
+
+(define (with-output-to-string thunk)
+  (call-with-output-string
+    (lambda (out)
+      (let ((old-out (current-output-port)))
+        (set-output-port out)
+        (thunk)
+        (set-output-port old-out)))))
+
+(define (write-to-string x)
+  (with-output-to-string
+    (lambda ()
+      (write x))))
+
+(define (geiser:completions prefix . rest)
+  rest
+  (sort string-ci<?
+        (filter (lambda (el)
+                  (string-prefix? prefix el))
+                (map write-to-string (apply append (oblist))))))


### PR DESCRIPTION
Hi,

I'm working on adapting Geiser to be able to use Tinyscheme. I've mostly been successful, getting completion and communication with REPL ready. There is one problem, however. My current implementation of `geiser:eval` (almost identical to the one for Chez Scheme) handles function calls correctly, but special forms such as `(define ...)` do not get properly evaluated, e.g.
`(geiser:eval #f '(define (double x) (* x 2)))`
runs fine, but trying to run `(double 10)` yields:
`Error: eval: unbound variable: double`
Perhaps you could suggest what I'm missing here. Below is my `geiser:eval` function:
```
(define (geiser:eval module form . rest)
    rest
    (let ((output (open-output-string))
	  (result (if module
                      (eval form (environment module))
                      (eval form))))
      (write `((result ,(write-to-string result))
               (output ,(get-output-string output))))
      (newline)))
```
Thanks