### PR TITLE
Make geiser-chicken-required-modules customizable

### DIFF
--- a/elisp/geiser-chicken.el
+++ b/elisp/geiser-chicken.el
@@ -109,8 +109,11 @@ this variable to t."
   :type 'integer
   :group 'geiser-chicken)
 
-(defvar geiser-chicken--required-modules
-  (list "chicken-doc" "apropos" "data-structures" "extras" "ports" "posix" "srfi-1" "srfi-13" "srfi-14" "srfi-18" "srfi-69" "tcp" "utils"))
+(geiser-custom--defcustom geiser-chicken-required-modules
+    (list "chicken-doc" "apropos" "data-structures" "extras" "ports" "posix" "srfi-1" "srfi-13" "srfi-14" "srfi-18" "srfi-69" "tcp" "utils")
+  "Modules automatically loaded in the Chicken REPL."
+  :type '(repeat string)
+  :group 'geiser-chicken)
 
 
 ;;; REPL support:
@@ -132,7 +135,7 @@ This function uses `geiser-chicken-init-file' if it exists."
                              geiser-chicken-load-path))
     ,@(and init-file (file-readable-p init-file) (list init-file))
     ,@(apply 'append (mapcar (lambda (m) (list "-R" m))
-			     geiser-chicken--required-modules)))))
+			     geiser-chicken-required-modules)))))
 
 (defconst geiser-chicken--prompt-regexp "#[^;]*;[^:0-9]*:?[0-9]+> ")
 


### PR DESCRIPTION
Some people (such as myself) may not want to start with these modules (or any) by default.